### PR TITLE
rework group cleaner 

### DIFF
--- a/acm-placements/all-openshift.yml
+++ b/acm-placements/all-openshift.yml
@@ -2,7 +2,7 @@
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: all-clusters
+  name: all-openshift
 spec:
   clusterConditions:
   - status: 'True'

--- a/cluster-maintenance/clean-groups.yml
+++ b/cluster-maintenance/clean-groups.yml
@@ -15,46 +15,44 @@ spec:
           namespace: default
         data:
           fake: holder so policy is not generated empty
-        
     {{- range $grp := (lookup "user.openshift.io/v1" "Group" "" "").items }}
-      {{- $ignoreUsers := "" }}
+      {{- $savedUsers := "" }}
       {{- $hasUserRemoved := false }}
-      {{- if eq (len $grp.users) 0 }}
-    - complianceType: mustnothave
-      objectDefinition:
-        kind: Group
-        apiVersion: user.openshift.io/v1
-        metadata:
-          name: {{ $grp.metadata.name }}
+      {{- if or (not $grp.users) (eq (len $grp.users) 0) }}
+        {{- /* There are no users in the group, mark as users removed */ -}}
+        {{- $hasUserRemoved = true }}
       {{- else }}
         {{- range $i, $usr := $grp.users }}
           {{- $user := false }}
           {{- $user = (lookup "user.openshift.io/v1" "User" "" $usr) }}
           {{- if not $user }}
+            {{- /* user is not in the cluster, mark to remove. */ -}}
             {{- $hasUserRemoved = true }}
-            {{- if eq (len $grp.users) 1 }}
+          {{- else }}
+            {{- /* user is in the cluster so we should save it for later */ -}}
+            {{- $tUsr := `
+        - %s` }}
+            {{- $savedUsers = (cat $savedUsers (printf $tUsr $usr)) }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- /* all users have been evaluated. */ -}}
+      {{- /* if there are no users in savedUsers list and hasUserRemoved we should remove the group */ -}}
+      {{- if and ($hasUserRemoved) (not $savedUsers) }}
     - complianceType: mustnothave
       objectDefinition:
         kind: Group
         apiVersion: user.openshift.io/v1
         metadata:
           name: {{ $grp.metadata.name }}
-            {{- end }}
-          {{- else }}
-            {{- $tUsr := `
-        - %s` }}
-            {{- $ignoreUsers = (cat $ignoreUsers (printf $tUsr $usr)) }}
-          {{- end }}
-          {{- if and ($hasUserRemoved) ($ignoreUsers) }}
+      {{- else if and ($hasUserRemoved) ($savedUsers) }}
     - complianceType: mustonlyhave
       objectDefinition:
         kind: Group
         apiVersion: user.openshift.io/v1
         metadata:
           name: {{ $grp.metadata.name }}
-        users: {{ $ignoreUsers }}
-          {{- end }}
-        {{- end }}
+        users: {{ $savedUsers }}
       {{- end }}
     {{- end }}
       


### PR DESCRIPTION
code changes and cleanup to correct issues when groups have zero users and make overall policy code cleaner and easier to read