### PR TITLE
Defaut worker scheduler

### DIFF
--- a/policies/cluster-configs/default-scheduler/bry-tam-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/bry-tam-worker-node-label.yml
@@ -1,0 +1,29 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: bry-tam-worker-node-label
+spec:
+  remediationAction: enforce
+  severity: low
+  object-templates-raw: |
+    {{- /* Lookup nodes that are not labeled with a known set of other labels like infra
+            then apply our standard label what will be used by the default scheduler
+     */ -}}
+    {{- $worker_nodes := (lookup "v1" "Node" "" "" "node-role.kubernetes.io/worker" 
+                                                    "!node-role.kubernetes.io/infra" 
+                                                    "!node-role.kubernetes.io/storage" 
+                                                    "!node-role.kubernetes.io/special-workload"
+                                                    "portworx!=enabled"
+                                                    ).items }}
+
+    {{- /* Add the default worker label to the nodes  */ -}}
+    {{- range $nd := $worker_nodes }}
+    - complianceType: musthave
+      objectDefinition:
+        kind: Node
+        apiVersion: v1
+        metadata:
+          name: {{ $nd.metadata.name }}
+          labels:
+            bry-tam/worker: ''
+    {{- end }}

--- a/policies/cluster-configs/default-scheduler/scheduler.yml
+++ b/policies/cluster-configs/default-scheduler/scheduler.yml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  defaultNodeSelector: 'bry-tam/worker='

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -16,7 +16,7 @@ spec:
 
     {{- /* Add the special-workload label to the node and remove the default worker label  */ -}}
     {{- range $nd := $worker_nodes }}
-      {{- if haskey $nd.metadata.labels "isSpecial" }}
+      {{- if eq (dig "isSpecial" "false" $nd.metadata.labels) "true" }}
     - complianceType: musthave
       metadataComplianceType: mustonlyhave
       objectDefinition:

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -25,7 +25,7 @@ spec:
           name: {{ $nd.metadata.name }}
           labels:
         {{- range $k, $v := $nd.metadata.labels }}
-          {{- if ne $k 'bry-tam/worker' }}
+          {{- if ne $k "bry-tam/worker" }}
               {{ $k }}: {{ (empty $v) | ternary "''" $v }}
           {{- end }}
         {{- end }}

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -27,7 +27,7 @@ spec:
           labels:
             portworx: enabled
         {{- range $k, $v := $nd.metadata.labels }}
-          {{- if ne $k "bry-tam/worker" "portworx" }}
+          {{- if not (eq $k "bry-tam/worker" "portworx") }}
             {{ $k }}: {{ $v | quote }}
           {{- end }}
         {{- end }}

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: bry-tam-worker-node-label
+  name: special-workload-worker-node-label
 spec:
   remediationAction: enforce
   severity: low

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -20,11 +20,13 @@ spec:
     - complianceType: musthave
       metadataComplianceType: mustonlyhave
       objectDefinition:
-        kind: Node
+        kind: ConfigMap
         apiVersion: v1
         metadata:
           name: {{ $nd.metadata.name }}
-          labels:
+          namespace: default
+        data:
+          labels: |
         {{- range $k, $v := $nd.metadata.labels }}
           {{- if ne $k "bry-tam/worker" }}
             {{ $k }}: {{ (empty $v) | ternary "''" $v }}

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: bry-tam-worker-node-label
+spec:
+  remediationAction: enforce
+  severity: low
+  object-templates-raw: |
+    {{- /* Lookup nodes that are not labeled with a known set of other labels like infra
+            then apply our standard label what will be used by the default scheduler
+     */ -}}
+    {{- $worker_nodes := (lookup "v1" "Node" "" "" "node-role.kubernetes.io/worker" 
+                                                    "!node-role.kubernetes.io/infra" 
+                                                    "!node-role.kubernetes.io/storage" 
+                                                    ).items }}
+
+    {{- /* Add the special-workload label to the node and remove the default worker label  */ -}}
+    {{- range $nd := $worker_nodes }}
+    - complianceType: musthave
+      metadataComplianceType: mustonlyhave
+      objectDefinition:
+        kind: Node
+        apiVersion: v1
+        metadata:
+          name: {{ $nd.metadata.name }}
+          labels:
+        {{- range $k, $v := $nd.metadata.labels }}
+          {{- if ne $k 'bry-tam/worker' }}
+              {{ $k }}: {{ (empty $v) | ternary "''" $v }}
+          {{- end }}
+        {{- end }}
+    {{- end }}

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -25,8 +25,9 @@ spec:
         metadata:
           name: {{ $nd.metadata.name }}
           labels:
+            portworx: enabled
         {{- range $k, $v := $nd.metadata.labels }}
-          {{- if ne $k "bry-tam/worker" }}
+          {{- if ne $k "bry-tam/worker" "portworx" }}
             {{ $k }}: {{ $v | quote }}
           {{- end }}
         {{- end }}

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -16,6 +16,7 @@ spec:
 
     {{- /* Add the special-workload label to the node and remove the default worker label  */ -}}
     {{- range $nd := $worker_nodes }}
+      {{- if haskey $nd.metadata.labels "isSpecial" }}
     - complianceType: musthave
       metadataComplianceType: mustonlyhave
       objectDefinition:
@@ -26,7 +27,8 @@ spec:
           labels:
         {{- range $k, $v := $nd.metadata.labels }}
           {{- if ne $k "bry-tam/worker" }}
-              {{ $k }}: {{ (empty $v) | ternary "''" $v }}
+            {{ $k }}: {{ (empty $v) | ternary "''" $v }}
           {{- end }}
         {{- end }}
+      {{- end }}
     {{- end }}

--- a/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
+++ b/policies/cluster-configs/default-scheduler/special-workload-worker-node-label.yml
@@ -20,16 +20,14 @@ spec:
     - complianceType: musthave
       metadataComplianceType: mustonlyhave
       objectDefinition:
-        kind: ConfigMap
+        kind: Node
         apiVersion: v1
         metadata:
           name: {{ $nd.metadata.name }}
-          namespace: default
-        data:
-          labels: |
+          labels:
         {{- range $k, $v := $nd.metadata.labels }}
           {{- if ne $k "bry-tam/worker" }}
-            {{ $k }}: {{ (empty $v) | ternary "''" $v }}
+            {{ $k }}: {{ $v | quote }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/policies/cluster-configs/generator.yml
+++ b/policies/cluster-configs/generator.yml
@@ -68,6 +68,18 @@ policies:
     manifests:
       - path: cluster-autoscaling/
 
+  - name: cluster-scheduler
+    policySets: 
+      - cluster-scheduler
+    manifests:
+      - path: default-scheduler/bry-tam-worker-node-label.yml
+      - path: default-scheduler/special-workload-worker-node-label.yml
+      - path: default-scheduler/scheduler.yml
+        extraDependencies:
+          - name: bry-tam-worker-node-label
+            kind: ConfigurationPolicy
+            compliance: "Compliant"
+
 policySets:
   - name: cluster-configs
     placement:
@@ -80,3 +92,7 @@ policySets:
   - name: cluster-autoscaling
     placement:
       placementName: "ft-autoscaling--enabled"
+
+  - name: cluster-scheduler
+    placement:
+      placementName: "ft-default-scheduler--enabled"


### PR DESCRIPTION
Add policies showcasing how to manage labels on nodes to set default scheduler on some and apply alternate label on others.  When applying the alternate label remove the default worker label