### PR TITLE
Cluster health eval

### DIFF
--- a/policies/cluster-health/README.md
+++ b/policies/cluster-health/README.md
@@ -1,0 +1,8 @@
+The purpose of this policy is to validate the OCP cluster is healthy.  This should be a single point to validate the cluster is:
+- updated to the version specified
+- all ClusterOperators are at that version and reporting healthy
+- all MachineConfigPools are healthy (not progressing, not degraded)
+- all nodes are healthy and schedulable
+  - updated to the rendered config matching the MCP
+  - are managed by an MCP
+- 

--- a/policies/cluster-health/clusteroperator.yml
+++ b/policies/cluster-health/clusteroperator.yml
@@ -4,7 +4,7 @@ kind: ConfigurationPolicy
 metadata:
   name: cluster-operator-status
 spec:
-  remediationAction: InformOnly
+  remediationAction: inform
   severity: high
   object-templates-raw: |
     {{/* ##  Get the current or desired version of the cluster ## */}}

--- a/policies/cluster-health/clusteroperator.yml
+++ b/policies/cluster-health/clusteroperator.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: cluster-operator-status
+spec:
+  remediationAction: InformOnly
+  severity: high
+  object-templates-raw: |
+    {{/* ##  Get the current or desired version of the cluster ## */}}
+    {{- $cVer := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version") }}
+    {{- $desiredVersion := $cVer.status.desired.version }}
+
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        metadata:
+          name: version
+        status:
+          history:
+            - version: {{ $desiredVersion }}
+              state: "Completed"
+          conditions:
+            - status: 'True'
+              type: Available
+            - status: 'False'
+              type: Failing
+            - status: 'False'
+              type: Progressing

--- a/policies/cluster-health/clusteroperator.yml
+++ b/policies/cluster-health/clusteroperator.yml
@@ -9,7 +9,7 @@ spec:
   object-templates-raw: |
     {{/* ##  Get the current or desired version of the cluster ## */}}
     {{- $cVer := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version") }}
-    {{- $desiredVersion := $cVer.status.desired.version }}
+    {{- $desiredVersion := (dig "desiredUpdate" "version" ($cVer.status.desired.version) $cVer.spec) }}
 
     {{/* ## Loop through the ClusterOperators to ensure they are healthy ## */}}
     {{- range $cOp := (lookup "config.openshift.io/v1" "ClusterOperator" "" "").items }}

--- a/policies/cluster-health/clusteroperator.yml
+++ b/policies/cluster-health/clusteroperator.yml
@@ -28,8 +28,6 @@ spec:
               type: Degraded
             - status: 'True'
               type: Available
-            - status: 'False'
-              type: Disabled
           versions:
             - name: operator
               version: {{ $desiredVersion }}

--- a/policies/cluster-health/clusterversion.yml
+++ b/policies/cluster-health/clusterversion.yml
@@ -9,7 +9,7 @@ spec:
   object-templates-raw: |
     {{/* ##  Get the current or desired version of the cluster ## */}}
     {{- $cVer := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version") }}
-    {{- $desiredVersion := $cVer.status.desired.version }}
+    {{- $desiredVersion := (dig "desiredUpdate" "version" ($cVer.status.desired.version) $cVer.spec) }}
 
     - complianceType: musthave
       objectDefinition:
@@ -28,3 +28,4 @@ spec:
               type: Failing
             - status: 'False'
               type: Progressing
+

--- a/policies/cluster-health/clusterversion.yml
+++ b/policies/cluster-health/clusterversion.yml
@@ -2,7 +2,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: cluster-operator-status
+  name: cluster-version-status
 spec:
   remediationAction: inform
   severity: high
@@ -11,26 +11,20 @@ spec:
     {{- $cVer := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version") }}
     {{- $desiredVersion := $cVer.status.desired.version }}
 
-    {{/* ## Loop through the ClusterOperators to ensure they are healthy ## */}}
-    {{- range $cOp := (lookup "config.openshift.io/v1" "ClusterOperator" "" "").items }}
-
     - complianceType: musthave
       objectDefinition:
         apiVersion: config.openshift.io/v1
-        kind: ClusterOperator
+        kind: ClusterVersion
         metadata:
-          name: {{ $cOp.metadata.name }}
+          name: version
         status:
+          history:
+            - version: {{ $desiredVersion }}
+              state: "Completed"
           conditions:
-            - status: 'False'
-              type: Progressing
-            - status: 'False'
-              type: Degraded
             - status: 'True'
               type: Available
             - status: 'False'
-              type: Disabled
-          versions:
-            - name: operator
-              version: {{ $desiredVersion }}
-    {{- end }}
+              type: Failing
+            - status: 'False'
+              type: Progressing

--- a/policies/cluster-health/generator.yml
+++ b/policies/cluster-health/generator.yml
@@ -22,6 +22,7 @@ policies:
       - path: clusterversion.yml
       - path: clusteroperator.yml
       - path: machineconfigpool.yml
+      - path: node.yml
 
 policySets:
   - name: cluster-health

--- a/policies/cluster-health/generator.yml
+++ b/policies/cluster-health/generator.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: gen-policy-clusterhealth
+policyDefaults:
+  namespace: bry-tam-policies
+  remediationAction: inform
+  ## turn off the default compliance annotations
+  categories: []
+  controls: []
+  standards: []
+  policySets:
+    - cluster-health
+placementBindingDefaults:
+  name: "cluster-helath-binding"
+
+policies:
+  - name: cluster-health-eval
+    remediationAction: enforce
+    manifests:
+      - path: clusteroperator.yml
+
+policySets:
+  - name: cluster-health
+    placement:
+      placementName: "env-bound-placement"

--- a/policies/cluster-health/generator.yml
+++ b/policies/cluster-health/generator.yml
@@ -19,6 +19,7 @@ policies:
   - name: cluster-health-eval
     remediationAction: enforce
     manifests:
+      - path: clusterversion.yml
       - path: clusteroperator.yml
 
 policySets:

--- a/policies/cluster-health/generator.yml
+++ b/policies/cluster-health/generator.yml
@@ -21,6 +21,7 @@ policies:
     manifests:
       - path: clusterversion.yml
       - path: clusteroperator.yml
+      - path: machineconfigpool.yml
 
 policySets:
   - name: cluster-health

--- a/policies/cluster-health/kustomization.yaml
+++ b/policies/cluster-health/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+generators:
+  - generator.yml

--- a/policies/cluster-health/machineconfigpool.yml
+++ b/policies/cluster-health/machineconfigpool.yml
@@ -7,6 +7,13 @@ spec:
   remediationAction: inform
   severity: high
   object-templates-raw: |
+    {{/* ##  Get the current or desired version of the cluster ## */}}
+    {{- $cVer := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version") }}
+    {{- $desiredVersion := semver (dig "desiredUpdate" "version" ($cVer.status.desired.version) $cVer.spec) }}
+
+    {{/* ##  Determine if an even numbered release by divide by two, and compare  if the result rounds up ## */}}
+    {{- $isEvenRelease := (eq (div $desiredVersion.Minor 2 | toInt)  (div (add $desiredVersion.Minor 1) 2 | toInt)) }}
+
     {{/* ##  Get the list of MachineConfigPools ## */}}
     {{- $mcpList := (lookup "machineconfiguration.openshift.io/v1" "MachineConfigPool" "" "").items }}
 
@@ -17,8 +24,17 @@ spec:
         kind: MachineConfigPool
         metadata:
           name: {{ $mcp.metadata.name }}
+
+      {{/* ##  Ensure the MCP is not paused based on the following rules ## */}}
+      {{/* ##  1. master MCP must not be paused ## */}}
+      {{/* ##  2. If the ClusterVersion.spec.channel does not start with eus ## */}}
+      {{/* ##  3. The ClusterVersion.spec.channel starts with eus and the cluster minor version is an even release ## */}}
+      {{- if or (eq $mcp.metadata.name "master")
+                (not (hasPrefix "eus" $cVer.spec.channel))
+                (and (hasPrefix "eus" $cVer.spec.channel) $isEvenRelease) }}
         spec:
           paused: false
+      {{- end }}
         status:
           conditions:
             - status: 'False'

--- a/policies/cluster-health/machineconfigpool.yml
+++ b/policies/cluster-health/machineconfigpool.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: machine-config-pool-status
+spec:
+  remediationAction: inform
+  severity: high
+  object-templates-raw: |
+    {{/* ##  Get the list of MachineConfigPools ## */}}
+    {{- $mcpList := (lookup "machineconfiguration.openshift.io/v1" "MachineConfigPool" "" "") }}
+
+    {{- range $mcp := $mcpList }}
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: MachineConfigPool
+        metadata:
+          name: {{ $mcp.metadata.name }}
+        spec:
+          paused: false
+        status:
+          conditions:
+            - status: 'False'
+              type: RenderDegraded
+            - status: 'False'
+              type: NodeDegraded
+            - status: 'False'
+              type: Degraded
+            - status: 'True'
+              type: Updated
+            - status: 'False'
+              type: Updating
+          degradedMachineCount: 0
+          readyMachineCount: '{{ $mcp.status.machineCount | toInt }}'
+          unavailableMachineCount: 0
+          updatedMachineCount: '{{ $mcp.status.machineCount | toInt }}'
+          observedGeneration: '{{ $mcp.metadata.generation | toInt }}'
+
+    {{- end }}

--- a/policies/cluster-health/machineconfigpool.yml
+++ b/policies/cluster-health/machineconfigpool.yml
@@ -8,7 +8,7 @@ spec:
   severity: high
   object-templates-raw: |
     {{/* ##  Get the list of MachineConfigPools ## */}}
-    {{- $mcpList := (lookup "machineconfiguration.openshift.io/v1" "MachineConfigPool" "" "") }}
+    {{- $mcpList := (lookup "machineconfiguration.openshift.io/v1" "MachineConfigPool" "" "").items }}
 
     {{- range $mcp := $mcpList }}
     - complianceType: musthave

--- a/policies/cluster-health/node.yml
+++ b/policies/cluster-health/node.yml
@@ -9,34 +9,62 @@ spec:
   object-templates-raw: |
     {{/* ##  Get the list of MachineConfigPools so we can get the rendered config name ## */}}
     {{- $mcpList := (lookup "machineconfiguration.openshift.io/v1" "MachineConfigPool" "" "").items }}
-    {{- $nodeList := (lookup "v1" "Node" "" "") }}
+    {{- $nodeList := (lookup "v1" "Node" "" "").items }}
     {{- $evaluatedNodes := list "" }}
     {{- $workerMCP := "" }}
- 
+
     {{/* ##  Loop through all the MCP except worker.  Worker will be evaluated last against any nodes not already found. ## */}}
     {{- range $mcp := $mcpList }}
       {{- if eq $mcp.metadata.name "worker" }}
         {{- $workerMCP = $mcp }}
         {{- continue }}
       {{- end }}
+      
+      {{- range $node := $nodeList }}
+        {{- $nodeMatches := true }}
 
-      {{- $nodeSelector := list "" }}
-      {{- if not (empty $mcp.spec.nodeSelector.matchLabels) }}
-        {{- range $k,$v := $mcp.spec.nodeSelector.matchLabels }}
-          $nodeSelector = append $nodeSelector (printf "%s=%s" $k ($v | quote))
-        {{- end }}
-      {{- else }}
-        {{- range $e := $mcp.spec.nodeSelector.matchExpressions }}
-          {{- if eq $e.operator "Exists" }}
-            $nodeSelector = append $nodeSelector $e.key
-          {{- else }}
-            $nodeSelector = append $nodeSelector (printf "%s %s (%s)" $e.key $e.operator ($e.values | join ","))
+        {{/* ##  determine how the nodeSelector is specified.   ## */}}
+        {{/* ##  There isn't a direct way to get the nodes from the MCP, so we are going to be creative ## */}}
+        {{- if not (empty $mcp.spec.nodeSelector.matchLabels) }}
+          {{- range $k,$v := $mcp.spec.nodeSelector.matchLabels }}
+            {{/* ##  does the node have the label listed ## */}}
+            {{- if ne (dig "labels" $k "NOTFOUND" $node.metadata) $v }}
+              {{- $nodeMatches = false }}
+              {{- break }}
+            {{- end }}
+          {{- end }}
+        {{- else }}  
+          {{- range $e := $mcp.spec.nodeSelector.matchExpressions }}
+            {{/* ##  When the operator is Exists it does not matter the value, the label must be there ## */}}
+            {{/* ##  If it is not there we can exit quickly as this node is not a match ## */}}
+            {{- if and (eq $e.operator "Exists") (eq (dig "labels" $e.key "NOTFOUND" $node.metadata) "NOTFOUND") }}
+              {{- $nodeMatches = false }}
+              {{- break }}
+            {{- else if ne $e.operator "Exists" }}
+              {{/* ##  For all other operators we need to see if the value matches what is specified ## */}}
+              {{- $labelFound := false }}
+              {{- range $val := $e.values }}
+                {{/* ##  find any positive matches, fun use of dig to find the label on the node and get the value ## */}}
+                {{- if eq (dig "labels" $e.key "NOTFOUND" $node.metadata) $val }}
+                  {{- $labelFound = true }}
+                {{- end }}
+              {{- end }}
+              
+              {{/* ##  check if we found the label within the $e.values ## */}}
+              {{/* ##  If the operator is "IN" any value found will satisfy the requirement ## */}}
+              {{/* ##  If the operator is "NOTIN" none of the values can be found ## */}}
+              {{- if or (and (eq $e.operator "In") (not $labelFound))  (and (eq $e.operator "NotIn") ($labelFound)) }}
+                {{- $nodeMatches = false }}
+              {{- end }}
+            {{- end }}
           {{- end }}
         {{- end }}
-      {{- end }}
 
-      {{- $mcpNodeList := (lookup "v1" "Node" "" "" $nodeSelector).items }}
-      {{- range $node := $mcpNodeList }}
+        {{/* ##  If we didn't find a match for the node in the selector exit this iteration ## */}}
+        {{- if not $nodeMatches }}
+          {{- continue }} 
+        {{- end }}
+
         {{/* ##  record the node name so we can exclude it when checking the worker MCP. ## */}}
         {{- $evaluatedNodes = append $evaluatedNodes $node.metadata.name }}
 

--- a/policies/cluster-health/node.yml
+++ b/policies/cluster-health/node.yml
@@ -1,0 +1,93 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: node-status
+spec:
+  remediationAction: inform
+  severity: high
+  object-templates-raw: |
+    {{/* ##  Get the list of MachineConfigPools so we can get the rendered config name ## */}}
+    {{- $mcpList := (lookup "machineconfiguration.openshift.io/v1" "MachineConfigPool" "" "").items }}
+    {{- $nodeList := (lookup "v1" "Node" "" "") }}
+    {{- $evaluatedNodes := list "" }}
+    {{- $workerMCP := "" }}
+ 
+    {{/* ##  Loop through all the MCP except worker.  Worker will be evaluated last against any nodes not already found. ## */}}
+    {{- range $mcp := $mcpList }}
+      {{- if eq $mcp.metadata.name "worker" }}
+        {{- $workerMCP = $mcp }}
+        {{- continue }}
+      {{- end }}
+
+      {{- $nodeSelector := list "" }}
+      {{- if not (empty $mcp.spec.nodeSelector.matchLabels) }}
+        {{- range $k,$v := $mcp.spec.nodeSelector.matchLabels }}
+          $nodeSelector = append $nodeSelector (printf "%s=%s" $k ($v | quote))
+        {{- end }}
+      {{- else }}
+        {{- range $e := $mcp.spec.nodeSelector.matchExpressions }}
+          {{- if eq $e.operator "Exists" }}
+            $nodeSelector = append $nodeSelector $e.key
+          {{- else }}
+            $nodeSelector = append $nodeSelector (printf "%s %s (%s)" $e.key $e.operator ($e.values | join ","))
+          {{- end }}
+        {{- end }}
+      {{- end }}
+
+      {{- $mcpNodeList := (lookup "v1" "Node" "" "" $nodeSelector).items }}
+      {{- range $node := $mcpNodeList }}
+        {{/* ##  record the node name so we can exclude it when checking the worker MCP. ## */}}
+        {{- $evaluatedNodes = append $evaluatedNodes $node.metadata.name }}
+
+    - complianceType: musthave
+      objectDefinition:
+        kind: Node
+        apiVersion: v1
+        metadata:
+          name: {{ $node.metadata.name }}
+          annotations:
+            machineconfiguration.openshift.io/currentConfig: {{ $mcp.spec.configuration.name }}
+            machineconfiguration.openshift.io/desiredConfig: {{ $mcp.spec.configuration.name }}
+            machineconfiguration.openshift.io/state: Done
+        status:
+          conditions:
+            - type: MemoryPressure
+              status: 'False'
+            - type: DiskPressure
+              status: 'False'
+            - type: PIDPressure
+              status: 'False'
+            - type: Ready
+              status: 'True'
+      {{- end }}
+    {{- end }}
+
+    {{/* ##  Loop through all the nodes excluding those that have been evaluated - remaining should have worker MCP config. ## */}}
+    {{/* ##  This should catch any nodes that are not selected by an MCP, which would prevent them from being updated. ## */}}
+    {{- range $node := $nodeList }}
+      {{- if (has $node.metadata.name $evaluatedNodes) }}
+        {{- continue }}
+      {{- end }}
+
+    - complianceType: musthave
+      objectDefinition:
+        kind: Node
+        apiVersion: v1
+        metadata:
+          name: {{ $node.metadata.name }}
+          annotations:
+            machineconfiguration.openshift.io/currentConfig: {{ $workerMCP.spec.configuration.name }}
+            machineconfiguration.openshift.io/desiredConfig: {{ $workerMCP.spec.configuration.name }}
+            machineconfiguration.openshift.io/state: Done
+        status:
+          conditions:
+            - type: MemoryPressure
+              status: 'False'
+            - type: DiskPressure
+              status: 'False'
+            - type: PIDPressure
+              status: 'False'
+            - type: Ready
+              status: 'True'
+    {{- end }}

--- a/policies/kustomization.yaml
+++ b/policies/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ./application-defaults/
   - ./cluster-version/
   - ./gatekeeper/
+  - ./cluster-health
 
 # commonAnnotations:
 #   argocd.argoproj.io/compare-options: IgnoreExtraneous


### PR DESCRIPTION
Create a policy set that can evaluate the health of the cluster, especially xonsider after a cluster upgrade.

It should check to validate the upgrade success, and cluster is healthy (ignoring any operators or user workloads that might be deployed)
ClusterVersion - Is it at the desired version, and reporting healthy.
ClusterOperator - all reporting new version, no degraded/progressing
MachineConfigPool - not paused (except EUS odd releases), no degraded/progressing pools, updated node count matches total node count. 
Nodes - all ready, all schedulable, match to MCP to value desired/current render config (account for nodes not selected by MCP which would catch nodes not upgraded)