### PR TITLE
block deleting olm configmap or job until after 12 hours

### DIFF
--- a/policies/cluster-maintenance/operator-lifecycle/clean-olm-jobs-configmaps.yml
+++ b/policies/cluster-maintenance/operator-lifecycle/clean-olm-jobs-configmaps.yml
@@ -13,7 +13,15 @@ object-templates-raw: |
   {{- end }}
 
 
+  {{/* ##  Need to ensure the ConfigMap is older than some period otherwise it will be removed during operator upgrade ## */}}
+  {{- $maxAgeHours := 12.0 }}
+
   {{- range $cm := (lookup "v1" "ConfigMap" "openshift-marketplace" "" "olm.managed=true").items }}
+    {{- $cmCreated := (toDate "2006-1-2T15:04:05Z" $cm.metadata.creationTimestamp) }}
+    {{- if lt (now.Sub $cmCreated).Hours $maxAgeHours }}
+      {{- continue }}
+    {{- end }}
+
     {{- if not (has $cm.metadata.name $currentCM) }}
   - complianceType: mustnothave
     objectDefinition:


### PR DESCRIPTION
Policy deleted the ConfigMap during operator upgrade.  By adding a date delay based on the ConfigMap age it will not cleanup inprogress upgrades.