### PR TITLE
Update policies for ACM 2.15

### DIFF
--- a/build/validate-policies.sh
+++ b/build/validate-policies.sh
@@ -66,6 +66,10 @@ if [ ! -d schemas ]; then
   curl -s -o crd-schema.py https://raw.githubusercontent.com/yannh/$KUBECONFORM/$KC_VERSION/scripts/openapi2jsonschema.py
   chmod a+x crd-schema.py
 
+  # curl -s -o requirements.txt https://raw.githubusercontent.com/yannh/$KUBECONFORM/$KC_VERSION/scripts/requirements.txt
+  # python3 -m ensurepip --upgrade
+  # python3 -m pip install -r ./requirements.txt
+
   echo "Converting CRDs to Schemas"
   ./crd-schema.py https://raw.githubusercontent.com/${OCM_REPOSITORY_OWNER}/governance-policy-propagator/main/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
   ./crd-schema.py https://raw.githubusercontent.com/${OCM_REPOSITORY_OWNER}/governance-policy-propagator/main/deploy/crds/policy.open-cluster-management.io_policies.yaml

--- a/policies/acm-configs/cluster-addon-config/README.md
+++ b/policies/acm-configs/cluster-addon-config/README.md
@@ -1,0 +1,13 @@
+# ClusterAddonConfig  resource configuration
+Policy ensures every governance-framework and config-policy-controller deployment has specified resource request and limits.  Used when pods are in OOMKill status
+
+## Dependencies
+  - None
+
+## Details
+ACM Minimal Version: 2.15
+
+Documentation: [latest](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html-single/add-ons/acm-managed-adv-config#setting-addondeploymentconfig-klusterlet-addons)
+
+---
+**Notes:**

--- a/policies/acm-configs/cluster-addon-config/addondeploymentconfig.yml
+++ b/policies/acm-configs/cluster-addon-config/addondeploymentconfig.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: clusteraddon-resource-config
+  namespace: open-cluster-management-hub
+spec:
+  agentInstallNamespace: open-cluster-management-agent-addon
+  resourceRequirements:
+  - containerID: "deployments:governance-policy-framework:governance-policy-framework-addon"
+    resources:
+      requests:
+        memory: 512Mi
+      limits:
+        memory: 1024Mi
+  - containerID: "deployments:config-policy-controller:config-policy-controller"
+    resources:
+      requests:
+        memory: 512Mi
+      limits:
+        memory: 1024Mi

--- a/policies/acm-configs/cluster-addon-config/clustermanagementaddon.yml
+++ b/policies/acm-configs/cluster-addon-config/clustermanagementaddon.yml
@@ -1,0 +1,22 @@
+---
+object-templates-raw: |
+  {{- range $cma := (lookup "addon.open-cluster-management.io/v1alpha1" "ClusterManagementAddOn" "" "").items }}
+    {{- if eq $cma.metadata.name "governance-policy-framework" "config-policy-controller" }}
+
+  - complianceType: mustonlyhave
+    objectDefinition:
+      apiVersion: addon.open-cluster-management.io/v1alpha1
+      kind: ClusterManagementAddOn
+      metadata:
+        name: {{ $cma.metadata.name }}
+      spec:
+        addOnMeta: '{{ $cma.spec.addOnMeta | toRawJson | toLiteral }}'
+        installStrategy: '{{ $cma.spec.installStrategy | toRawJson | toLiteral }}'
+        supportedConfigs:
+          - group: addon.open-cluster-management.io
+            resource: addondeploymentconfigs
+            defaultConfig:
+              name: clusteraddon-resource-config
+              namespace: open-cluster-management-hub
+    {{- end }}
+  {{- end }}

--- a/policies/acm-configs/cluster-addon-config/generator.yml
+++ b/policies/acm-configs/cluster-addon-config/generator.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: gen-policy-generator-addon-config
+policyDefaults:
+  namespace: bry-tam-policies
+  remediationAction: enforce
+  consolidateManifests: false
+  policySets:
+    - acm-addon-config
+
+placementBindingDefaults:
+  name: "acm-addon-config-binding"
+
+policies:
+  - name: acm-addon-config
+    remediationAction: enforce
+    manifests:
+      - path: addondeploymentconfig.yml
+        name: addon-deployment-config
+        complianceType: mustonlyhave
+
+      - path: clustermanagementaddon.yml
+        name: cluster-management-addon
+
+policySets:
+  - name: acm-addon-config
+    placement:
+      placementName: "env-bound-hub-placement"

--- a/policies/acm-configs/cluster-addon-config/kustomization.yaml
+++ b/policies/acm-configs/cluster-addon-config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - ./generator.yml

--- a/policies/acm-configs/feature-flags-placement/feature-flag-placements.yml
+++ b/policies/acm-configs/feature-flags-placement/feature-flag-placements.yml
@@ -23,13 +23,9 @@ object-templates-raw: |
           - requiredClusterSelector:
               labelSelector:
                 matchExpressions:
-                  - key: vendor
-                    operator: In
-                    values:
-                      - OpenShift
                   - key: {{ $feature._0 }}
-                    operator: {{ (empty $feature._1) | ternary "Exists" "In" }}
-      {{- if not (empty $feature._1) }}
+                    operator: {{ (eq "exists" $feature._1) | ternary "Exists" "In" }}
+      {{- if not (eq "exists" $feature._1) }}
                     values:
                       - {{ $feature._1 }}
       {{- end }}

--- a/policies/acm-configs/klusterlet-infra/generator.yml
+++ b/policies/acm-configs/klusterlet-infra/generator.yml
@@ -22,11 +22,11 @@ policies:
 
       - path: infra-addondeploymentconfig.yml
         name: infra-deploy-config
-        complianceType: musthave
+        complianceType: mustonlyhave
 
       - path: worker-addondeploymentconfig.yml
         name: worker-deploy-config
-        complianceType: musthave
+        complianceType: mustonlyhave
 
 policySets:
   - name: acm-klusterlet-infra

--- a/policies/acm-configs/klusterlet-infra/infra-addondeploymentconfig.yml
+++ b/policies/acm-configs/klusterlet-infra/infra-addondeploymentconfig.yml
@@ -5,6 +5,7 @@ metadata:
   name: infra-deploy-config
   namespace: open-cluster-management-hub
 spec:
+  agentInstallNamespace: open-cluster-management-agent-addon
   nodePlacement:
     nodeSelector:
       node-role.kubernetes.io/infra: ""

--- a/policies/acm-configs/klusterlet-infra/infra-selector-tolerations.yml
+++ b/policies/acm-configs/klusterlet-infra/infra-selector-tolerations.yml
@@ -1,10 +1,5 @@
 ---
 object-templates-raw: |
-  {{/* ##  Set Infra identifiers ## */}}
-  {{- $infraNodeSelector := "\"node-role.kubernetes.io/infra\": \"\"" }}
-  {{- $workerNodeSelector := "\"node-role.kubernetes.io/worker\": \"\"" }}
-  {{- $infraTolerationKey := "node-role.kubernetes.io/infra" }}
-
   {{/* ##  Gather all ManagedClusters using the ManagedClusterInfo object since this has node info ## */}}
   {{- range $mc := (lookup "internal.open-cluster-management.io/v1beta1" "ManagedClusterInfo" "" "").items }}
 
@@ -23,8 +18,8 @@ object-templates-raw: |
       kind: ManagedCluster
       metadata:
         annotations:
-          open-cluster-management/nodeSelector: '{{ printf "{%s}" ($hasInfra | ternary $infraNodeSelector $workerNodeSelector) }}'
-          open-cluster-management/tolerations: '[{"key":"{{ $infraTolerationKey }}","operator":"Exists"}]'
+          open-cluster-management/nodeSelector: '{"node-role.kubernetes.io/{{ $hasInfra | ternary "infra" "worker" }}":""}'
+          open-cluster-management/tolerations: '[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]'
         name: {{ $mc.metadata.name }}
 
     {{/* ##  Gather all ClusterManagementAddOn ## */}}

--- a/policies/acm-configs/klusterlet-infra/worker-addondeploymentconfig.yml
+++ b/policies/acm-configs/klusterlet-infra/worker-addondeploymentconfig.yml
@@ -5,6 +5,7 @@ metadata:
   name: worker-deploy-config
   namespace: open-cluster-management-hub
 spec:
+  agentInstallNamespace: open-cluster-management-agent-addon
   nodePlacement:
     nodeSelector:
       node-role.kubernetes.io/worker: ""

--- a/policies/acm-configs/kustomization.yaml
+++ b/policies/acm-configs/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - ./policy-alerts/
   - ./observability/
   - ./managedserviceaccount/
-  - ./klusterlet-infra/
+#  - ./klusterlet-infra/
   - ./kubeadmin-config-trustca/
   - ./set-cluster-debug-mode/
-  - ./remove-kubeadmin-pass
+  # - ./cluster-addon-config/

--- a/policies/acm-configs/observability/generator.yml
+++ b/policies/acm-configs/observability/generator.yml
@@ -61,6 +61,15 @@ policies:
             kind: ConfigurationPolicy
             compliance: "Compliant"
 
+      - path: managedcluster.yml
+        name: annotate-hub-info-managedcluster
+        objectSelector:
+          matchExpressions:
+            - key: vendor
+              operator: In
+              values:
+                - OpenShift
+
   - name: acm-observe-status
     remediationAction: inform
     dependencies:

--- a/policies/acm-configs/observability/managedcluster.yml
+++ b/policies/acm-configs/observability/managedcluster.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  annotations:
+    hub-alertmanager-url: '{{ (lookup "route.openshift.io/v1" "Route" "open-cluster-management-observability" "alertmanager").spec.host }}'
+    hub-cluster-id: '{{hub $.ManagedClusterLabels.clusterID | replace "-" "" | trunc 19 hub}}'

--- a/policies/acm-configs/observability/observability.yml
+++ b/policies/acm-configs/observability/observability.yml
@@ -3,8 +3,23 @@ apiVersion: observability.open-cluster-management.io/v1beta2
 kind: MultiClusterObservability
 metadata:
   name: observability
+  annotations:
+    mco-disable-alerting: 'true'
+
 spec:
   observabilityAddonSpec: {}
+
+  ## to enable MCOA set the below to true and remove the annotation above.
+  ## Note this should not be done before 2.15.1 release has verified to fix MCOA
+  capabilities:
+    platform:
+      metrics:
+        default:
+          enabled: '{{hub default false (not (empty (index $.ManagedClusterLabels "observability-mcoa"))) | toRawJson | toBool hub}}'
+    userWorkloads:
+      metrics:
+        default:
+          enabled: '{{hub default false (not (empty (index $.ManagedClusterLabels "observability-mcoa"))) | toRawJson | toBool hub}}'
 
   storageConfig:
     metricObjectStorage:

--- a/policies/acm-configs/remove-kubeadmin-pass/README.md
+++ b/policies/acm-configs/remove-kubeadmin-pass/README.md
@@ -1,6 +1,9 @@
 # ACM Remove kubeadmin password
 Policy removes the kubeadmin password and reference from `ClusterDeployment`
 
+## DO NOT USE
+This policy causes unintended consequences when the reference is removed form the ClusterDeployment.
+
 ## Dependencies
   - None
 

--- a/policies/cluster-configs/generator.yml
+++ b/policies/cluster-configs/generator.yml
@@ -11,8 +11,7 @@ policyDefaults:
   categories: []
   controls: []
   standards: []
-  customMessage:
-    noncompliant: "{{.DefaultMessage}} - diff: '{{ .Policy.status.relatedObjects[0].properties.diff }}'"
+
   policySets:
     - cluster-configs
 placementBindingDefaults:
@@ -89,18 +88,39 @@ policies:
     manifests:
       - path: etcd-backup/
 
+  ### Should only use one of the cluster-monitoring-config or the -mcoa.
+  ### This is dependent on how observability is configured
+  ### Both are included to give example how to configure the cluster.
   - name: ocp-monitoring
     manifests:
-      - path: monitoring/
+      - path: monitoring/cluster-monitoring-config.yml
+        name: cluster-monitoring-config
+        remediationAction: InformOnly
+
+      - path: monitoring/user-workload-monitoring-config.yml
+        name: user-workload-monitoring-config
+        remediationAction: InformOnly
+
+      - path: monitoring/cluster-monitoring-config-mcoa.yml
+        name: cluster-monitoring-config-mcoa
+        remediationAction: Enforce
+
+      - path: monitoring/user-workload-monitoring-config-mcoa.yml
+        name: user-workload-monitoring-config-mcoa
+        remediationAction: Enforce
 
   - name: node-kubeletconfigs
     manifests:
       - path: kubeletconfig/
 
+  - name: node-runtimes
+    manifests:
+      - path: nodes/node-cluster.yml
+        name: node-cgroups
+      - path: nodes/node-crio-runtime.yml
+        name: node-crio-runtime
+
   - name: infra-nodes
-    # dependencies:
-    #   - name: etcd-encryption
-    #     compliance: "Compliant"
     policySets:
       - cluster-configs-infra
     manifests:
@@ -110,9 +130,6 @@ policies:
       - path: machineconfigpools/infra.yml
 
   - name: storage-nodes
-    # dependencies:
-    #   - name: etcd-encryption
-    #     compliance: "Compliant"
     policySets:
       - cluster-configs-storage
     manifests:

--- a/policies/cluster-configs/image-registry/imageregistry-config.yml
+++ b/policies/cluster-configs/image-registry/imageregistry-config.yml
@@ -26,6 +26,6 @@ spec:
               bucket: {{ $objBucket.spec.endpoint.bucketName }}
               encrypt: false
               region: us-east-1
-              regionEndpoint: https://{{ $objBucket.spec.endpoint.bucketHost }}:{{ $objBucket.spec.endpoint.bucketPort }}
+              regionEndpoint: https://{{ (lookup "route.openshift.io/v1" "Route" "openshift-storage" "s3").spec.host }}
               trustedCA:
                 name: image-registry-s3-bundle

--- a/policies/cluster-configs/monitoring/cluster-monitoring-config-mcoa.yml
+++ b/policies/cluster-configs/monitoring/cluster-monitoring-config-mcoa.yml
@@ -1,17 +1,5 @@
 ---
 object-templates-raw: |
-  {{- $isLocalCluster := (ne "" "{{hub index $.ManagedClusterLabels "local-cluster" hub}}") }}
-  {{- $obsEnabled := false }}
-  {{- $hubInfo := "" }}
-  {{- $secretSuffix := ""}}
-
-  {{- $obsHubInfoSecret := (lookup "v1" "Secret" ($isLocalCluster | ternary "open-cluster-management-observability" "open-cluster-management-addon-observability") "hub-info-secret") }}
-  {{- if $obsHubInfoSecret }}
-    {{- $obsEnabled = true }}
-    {{- $hubInfo = (index $obsHubInfoSecret.data "hub-info.yaml") | base64dec | fromYaml }}
-    {{- $secretSuffix = (printf "-%s" (index $hubInfo "hub-cluster-id")) }}
-  {{- end }}
-
   - complianceType: musthave
     objectDefinition:
       apiVersion: v1
@@ -56,21 +44,22 @@ object-templates-raw: |
               - operator: Exists
                 key: node-role.kubernetes.io/infra
 
-  {{- if $obsEnabled }}
+  {{hub- $ManagedClusterAnnotations := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" $.ManagedClusterName).metadata.annotations hub}}
+  {{hub- if not (empty (index $ManagedClusterAnnotations "hub-cluster-id")) hub}}
             additionalAlertmanagerConfigs:
             - apiVersion: v2
               bearerToken:
                 key: token
-                name: observability-alertmanager-accessor{{ $secretSuffix }}
+                name: 'observability-alertmanager-accessor-{{hub index $ManagedClusterAnnotations "hub-cluster-id" hub}}'
               scheme: https
               staticConfigs:
-              - {{ trimAll "/" (printf "alertmanager-open-cluster-management-observability.%s" (regexFind "apps.*?/" (index $hubInfo "observatorium-api-endpoint"))) }}
+              - {{hub index $ManagedClusterAnnotations "hub-alertmanager-url" hub}}
               tlsConfig:
                 ca:
                   key: service-ca.crt
-                  name: hub-alertmanager-router-ca{{ $secretSuffix }}
+                  name: 'hub-alertmanager-router-ca-{{hub index $ManagedClusterAnnotations "hub-cluster-id" hub}}'
                 insecureSkipVerify: false
-  {{- end }}
+  {{hub- end hub}}
             externalLabels:
               instance_name: {{ $n := split "." (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.apiServerURL }}{{ $n._1 }}
               managed_cluster: {{ fromClusterClaim "id.openshift.io" }}

--- a/policies/cluster-configs/monitoring/user-workload-monitoring-config-mcoa.yml
+++ b/policies/cluster-configs/monitoring/user-workload-monitoring-config-mcoa.yml
@@ -1,17 +1,5 @@
 ---
 object-templates-raw: |
-  {{- $isLocalCluster := (ne "" "{{hub index $.ManagedClusterLabels "local-cluster" hub}}") }}
-  {{- $obsEnabled := false }}
-  {{- $hubInfo := "" }}
-  {{- $secretSuffix := ""}}
-
-  {{- $obsHubInfoSecret := (lookup "v1" "Secret" ($isLocalCluster | ternary "open-cluster-management-observability" "open-cluster-management-addon-observability") "hub-info-secret") }}
-  {{- if $obsHubInfoSecret }}
-    {{- $obsEnabled = true }}
-    {{- $hubInfo = (index $obsHubInfoSecret.data "hub-info.yaml") | base64dec | fromYaml }}
-    {{- $secretSuffix = (printf "-%s" (index $hubInfo "hub-cluster-id")) }}
-  {{- end }}
-
   - complianceType: musthave
     objectDefinition:
       apiVersion: v1
@@ -46,21 +34,22 @@ object-templates-raw: |
               product: {{ fromClusterClaim "product.open-cluster-management.io" }}
               managed_cluster: {{ fromClusterClaim "id.openshift.io" }}
 
-  {{- if $obsEnabled }}
+  {{hub- $ManagedClusterAnnotations := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" $.ManagedClusterName).metadata.annotations hub}}
+  {{hub- if not (empty (index $ManagedClusterAnnotations "hub-cluster-id")) hub}}
             additionalAlertmanagerConfigs:
             - apiVersion: v2
               bearerToken:
                 key: token
-                name: observability-alertmanager-accessor{{ $secretSuffix }}
+                name: 'observability-alertmanager-accessor-{{hub index $ManagedClusterAnnotations "hub-cluster-id" hub}}'
               scheme: https
               staticConfigs:
-              - {{ trimAll "/" (printf "alertmanager-open-cluster-management-observability.%s" (regexFind "apps.*?/" (index $hubInfo "observatorium-api-endpoint"))) }}
+              - {{hub index $ManagedClusterAnnotations "hub-alertmanager-url" hub}}
               tlsConfig:
                 ca:
                   key: service-ca.crt
-                  name: hub-alertmanager-router-ca{{ $secretSuffix }}
+                  name: 'hub-alertmanager-router-ca-{{hub index $ManagedClusterAnnotations "hub-cluster-id" hub}}'
                 insecureSkipVerify: false
-  {{- end }}
+  {{hub- end hub}}
 
           prometheusOperator:
             nodeSelector:

--- a/policies/cluster-configs/nodes/node-cluster.yml
+++ b/policies/cluster-configs/nodes/node-cluster.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+spec:
+  cgroupMode: "v2"

--- a/policies/cluster-configs/nodes/node-crio-runtime.yml
+++ b/policies/cluster-configs/nodes/node-crio-runtime.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: crio-default-runtime
+spec:
+  containerRuntimeConfig:
+    defaultRuntime: crun
+  machineConfigPoolSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/mco-built-in
+        operator: Exists

--- a/policies/cluster-version/admin-acks-configmap.yml
+++ b/policies/cluster-version/admin-acks-configmap.yml
@@ -8,3 +8,6 @@ data:
   ack-4.11-kube-1.25-api-removals-in-4.12: "true"
   ack-4.12-kube-1.26-api-removals-in-4.13: "true"
   ack-4.13-kube-1.27-api-removals-in-4.14: "true"
+  ack-4.15-kube-1.29-api-removals-in-4.16: "true"
+  ack-4.18-kube-1.32-api-removals-in-4.19: "true"
+  ack-4.19-admissionregistration-v1beta1-api-removals-in-4.20: "true"

--- a/policies/operators/acm/generator.yml
+++ b/policies/operators/acm/generator.yml
@@ -45,4 +45,4 @@ policies:
 policySets:
   - name: acm-operator
     placement:
-      placementName: "ft-acm-hub"
+      placementName: "ft-acm-hub--exists"

--- a/policies/operators/acm/operatorpolicy.yml
+++ b/policies/operators/acm/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: release-2.14
+    channel: release-2.15
     name: advanced-cluster-management
     namespace: open-cluster-management
     source: redhat-operators

--- a/policies/operators/acs/sensor/securedcluster.yml
+++ b/policies/operators/acs/sensor/securedcluster.yml
@@ -16,7 +16,7 @@ spec:
     timeoutSeconds: 20
     listenOnEvents: true
   centralEndpoint: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}'
-  clusterName: '{{hub .ManagedClusterName hub}}'
+  clusterName: '{{hub $.ManagedClusterName hub}}'
   monitoring:
     openshift:
       enabled: true

--- a/policies/operators/ansible-automation-platform/operatorpolicy.yml
+++ b/policies/operators/ansible-automation-platform/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: stable-2.5
+    channel: stable-2.6
     name: ansible-automation-platform-operator
     namespace: ansible-automation-platform
     source: redhat-operators

--- a/policies/operators/cert-manager/operatorpolicy.yml
+++ b/policies/operators/cert-manager/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: stable-v1.16
+    channel: stable-v1.18
     name: openshift-cert-manager-operator
     namespace: cert-manager-operator
     source: redhat-operators

--- a/policies/operators/cluster-logging/loki/health/loki-status.yml
+++ b/policies/operators/cluster-logging/loki/health/loki-status.yml
@@ -14,7 +14,7 @@ object-templates-raw: |
       status:
         conditions:
         {{- range $c := $loki.status.conditions }}
-          {{- if eq $c.type "Pending" }}
+          {{- if eq $c.type "Pending" "Failed" }}
             {{- $_ := set $c "status" "False" }}
           {{- else }}
             {{- $_ := set $c "status" "True" }}

--- a/policies/operators/cluster-logging/operatorpolicy.yml
+++ b/policies/operators/cluster-logging/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: stable-6.2
+    channel: stable-6.4
     name: cluster-logging
     namespace: openshift-logging
     source: redhat-operators

--- a/policies/operators/data-foundation/generator.yml
+++ b/policies/operators/data-foundation/generator.yml
@@ -45,9 +45,8 @@ policies:
       - path: console.yml
         name: odf-console
 
-      # commented out until bug https://issues.redhat.com/browse/ACM-23563
-      # - path: storagesystem.yml
-      #   name: storagesystem
+      - path: storagesystem.yml
+        name: storagesystem
 
       - path: storagecluster.yml
         name: storagecluster

--- a/policies/operators/gitops/argocd-instances/base/argocd.yml
+++ b/policies/operators/gitops/argocd-instances/base/argocd.yml
@@ -19,7 +19,7 @@ spec:
     resources:
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 512Mi
       requests:
         cpu: 125m
         memory: 128Mi

--- a/policies/operators/gitops/argocd-policygenerator.yml
+++ b/policies/operators/gitops/argocd-policygenerator.yml
@@ -25,6 +25,12 @@ spec:
     volumeMounts:
     - mountPath: /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
       name: policy-generator
+    - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      subPath: ca-bundle.crt
+      name: cluster-root-ca-bundle
     volumes:
     - emptyDir: {}
       name: policy-generator
+    - configMap:
+        name: cluster-root-ca-bundle
+      name: cluster-root-ca-bundle

--- a/policies/operators/gitops/cluster-root-ca-configmap.yml
+++ b/policies/operators/gitops/cluster-root-ca-configmap.yml
@@ -4,5 +4,5 @@ kind: ConfigMap
 metadata:
   labels:
     config.openshift.io/inject-trusted-cabundle: 'true'
-  name: image-registry-s3-bundle
-  namespace: openshift-config
+  name: cluster-root-ca-bundle
+  namespace: openshift-gitops

--- a/policies/operators/gitops/generator.yml
+++ b/policies/operators/gitops/generator.yml
@@ -73,6 +73,9 @@ policies:
       - path: argocd-policygenerator.yml
         name: argo-policygenerator
 
+      - path: cluster-root-ca-configmap.yml
+        name: cluster-root-ca-configmap
+
       - path: applicationset-config/managedclustersetbinding.yml
         name: applicationset-clusterbinding
 
@@ -94,4 +97,4 @@ policySets:
 
   - name: gitops-acm-hub
     placement:
-      placementName: "ft-acm-hub"
+      placementName: "ft-acm-hub--exists"

--- a/policies/operators/gitops/operatorpolicy.yml
+++ b/policies/operators/gitops/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: gitops-1.17
+    channel: gitops-1.19
     config:
       env:
         - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES

--- a/policies/operators/loki/operatorpolicy.yml
+++ b/policies/operators/loki/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: stable-6.2
+    channel: stable-6.4
     name: loki-operator
     namespace: openshift-operators-redhat
     source: redhat-operators

--- a/policies/operators/servicemesh/README.md
+++ b/policies/operators/servicemesh/README.md
@@ -4,6 +4,7 @@ Installs the ServiceMesh Operator.
 ## Dependencies
   - [OpenTelemetry Operator](../opentelemetry/)
   - [Tempo Operator](../tempo/)
+  - [Cluster Observability Operator](../cluster-observability/)
   - s3 Storage - Current configuration showcases using [ODF Operator](../data-foundation/)
   - [Kiali Operator](../kiali/)
 

--- a/policies/operators/servicemesh/controlplane/istiorevisiontag-default.yml
+++ b/policies/operators/servicemesh/controlplane/istiorevisiontag-default.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: sailoperator.io/v1
+kind: IstioRevisionTag
+metadata:
+  name: default
+spec:
+  targetRef:
+    kind: Istio
+    name: default

--- a/policies/operators/servicemesh/controlplane/kiali.yml
+++ b/policies/operators/servicemesh/controlplane/kiali.yml
@@ -6,7 +6,6 @@ metadata:
   namespace: istio-system
 spec:
   deployment:
-    istio_namespace: istio-system
     logger:
       log_level: debug
 
@@ -18,9 +17,6 @@ spec:
       thanos_proxy:
         enabled: true
       url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
-
-    istio:
-      ingress_gateway_namespace: istio-ingress
 
     tracing:
       enabled: true

--- a/policies/operators/servicemesh/generator.yml
+++ b/policies/operators/servicemesh/generator.yml
@@ -60,6 +60,9 @@ policies:
       - path: controlplane/istiocni.yml
         name: istio-cni
 
+      - path: controlplane/istiorevisiontag-default.yml
+        name: istiorevisiontag-default
+
       - path: tracing/namespace.yml
         name: tracing-namespace
 
@@ -74,6 +77,9 @@ policies:
 
       - path: tracing/opentelemetrycollector.yml
         name: otel-collector
+
+      - path: tracing/serviceaccount.yml
+        name: otel-serviceaccount
 
       - path: tracing/opentelemetry-rolebinding.yml
         name: otel-collector-rolebinding
@@ -92,6 +98,9 @@ policies:
 
       - path: tracing/tempostack.yml
         name: tracing-ossm-tempostack
+
+      - path: tracing/uiplugin.yml
+        name: tracing-uiplugin
 
       - path: controlplane/kiali-clusterrolebinding.yml
         name: kiali-clusterrolebinding

--- a/policies/operators/servicemesh/kustomization.yaml
+++ b/policies/operators/servicemesh/kustomization.yaml
@@ -22,3 +22,7 @@ patchesJson6902:
     - op: add
       path: /spec/policies/-
       value: 'tempo-operator'
+
+    - op: add
+      path: /spec/policies/-
+      value: 'cluster-observability-operator'

--- a/policies/operators/servicemesh/operatorpolicy.yml
+++ b/policies/operators/servicemesh/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-    channel: stable-3.0
+    channel: stable-3.2
     name: servicemeshoperator3
     namespace: openshift-servicemesh-operator
     source: redhat-operators

--- a/policies/operators/servicemesh/tracing/opentelemetrycollector.yml
+++ b/policies/operators/servicemesh/tracing/opentelemetrycollector.yml
@@ -71,18 +71,17 @@ spec:
             - prometheus
           receivers:
             - spanmetrics
+          processors:
+            - k8sattributes
       telemetry:
         metrics:
-          address: 0.0.0.0:8888
 
-  configVersions: 3
+
   daemonSetUpdateStrategy: {}
   deploymentUpdateStrategy: {}
   ingress:
     route: {}
-  ipFamilyPolicy: SingleStack
 
-  podDnsConfig: {}
   replicas: 1
   resources: {}
   targetAllocator:

--- a/policies/operators/servicemesh/tracing/serviceaccount.yml
+++ b/policies/operators/servicemesh/tracing/serviceaccount.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: tracing-system

--- a/policies/operators/servicemesh/tracing/uiplugin.yml
+++ b/policies/operators/servicemesh/tracing/uiplugin.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: distributed-tracing
+spec:
+  type: DistributedTracing

--- a/policies/operators/talm/generator.yml
+++ b/policies/operators/talm/generator.yml
@@ -38,4 +38,4 @@ policies:
 policySets:
   - name: talm-operator
     placement:
-      placementName: "ft-acm-hub"
+      placementName: "ft-acm-hub--exists"

--- a/policies/operators/talm/operatorpolicy.yml
+++ b/policies/operators/talm/operatorpolicy.yml
@@ -18,7 +18,7 @@ spec:
   severity: critical
   upgradeApproval: Automatic
   subscription:
-  # channel: '{{hub (index .ManagedClusterLabels "openshiftVersion-major-minor") hub}}'
+  # channel: '{{hub (index $.ManagedClusterLabels "openshiftVersion-major-minor") hub}}'
   ## turns out the operator is broken if you don't specify stable.  Leaving the above to remember the fun times.
     channel: stable
     name: topology-aware-lifecycle-manager

--- a/template-examples/kustomize-monitoring-config/README.md
+++ b/template-examples/kustomize-monitoring-config/README.md
@@ -1,6 +1,10 @@
 # Cluster Monitoring Config with Kustomize
 This approach used per-cluster overlays to configure the cluster-monitoring-config ConfigMap when ACM Observability is enabled.
 
+Changes in ACM 2.15 have broken the configuration demonstrated here.   The Alertmanager Accessor and Router-CA secret names used in the `additionalAlertmanagerConfigs` section now includes an identifer suffix for the hub cluster.
+
+This example could be updated to account for that change, but currently the code does not.
+
 ## Dependencies
   - None
 

--- a/template-examples/snippets/cluster-specific-range.yml
+++ b/template-examples/snippets/cluster-specific-range.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: cluster-monitoring-view-access-role-bindings
+  namespace: default
+spec:
+  copyPolicyMetadata: false
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: example-role-cluster-monitoring-view-configs-policy
+        spec:
+          remediationAction: inform
+          severity: medium
+          object-templates-raw: |
+            {{hub- $data := (fromConfigMap "" (index .ManagedClusterLabels "cluster.open-cluster-management.io/clusterset") $.PolicyMetadata.name | fromYaml) hub}}
+            - complianceType: mustonlyhave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  labels:
+                    org: example
+                  name: example-role-cluster-monitoring-view
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: cluster-monitoring-view
+                subjects:
+            {{hub- range $view_role := $data hub}}
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: Group
+                  name: {{hub $view_role hub}}
+            {{hub else hub}}
+                  []
+            {{hub- end hub}}

--- a/template-examples/snippets/combine-and-alter-lists.yml
+++ b/template-examples/snippets/combine-and-alter-lists.yml
@@ -1,0 +1,48 @@
+---
+object-templates-raw: |
+  {{- $nncp_configs := concat (lookup "nmstate.io/v1" "NodeNetworkConfigurationPolicy" "" "static-routes-app-test-metallb-bgp").spec.desiredState.routes.config
+                              (lookup "nmstate.io/v1" "NodeNetworkConfigurationPolicy" "" "static-routes-app-app-metallb-bgp").spec.desiredState.routes.config
+                              (lookup "nmstate.io/v1" "NodeNetworkConfigurationPolicy" "" "static-routes-app-tmp-metallb-bgp").spec.desiredState.routes.config
+  }}
+
+  - complianceType: mustonlyhave
+    objectDefinition:
+      apiVersion: nmstate.io/v1
+      kind: NodeNetworkConfigurationPolicy
+      metadata:
+        name: node-nncp-policy
+      spec:
+        nodeSelector:
+          kubernetes.io/hostname: node.org.com
+        desiredState:
+          routes:
+            config:
+              - destination: '{{ fromConfigMap "openshift-config" "cluster-info" "odf_subnet" }}'
+                next-hop-interface: odf-shim
+
+            {{- range $i := $nncp_configs }}
+              {{- if $i.state }}
+                {{- $_ := set $i "state" "absent" }}
+              {{- end }}
+              - {{ $i | toRawJson | toLiteral }}
+            {{- end }}
+
+          interfaces:
+          - name: bond1
+            description: bond1
+            type: bond
+            state: up
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
+            link-aggregation:
+              mode: 802.3ad
+              options:
+                miimon: "100"
+                lacp_rate: "slow"
+                xmit_hash_policy: "layer2"
+              port:
+              - ens1fXnpY
+              - ens1fXnpY
+            mtu: 8900


### PR DESCRIPTION
- Update ACM Operator to 2.15
- Update ACM Observability to MCOA
- Upate Feature Flag Placement Policy to allow "exists" as a value
- Set node cgroups v2 and CRIO runtime to match 4.18 defaults
- Update cert-manager to 1.18 release channel
- Update Service Mesh to 3.2
- Update Kiali version
- Update OpenShift Logging to 6.4
- Update GitOps Operator to 1.19
- Update Loki Operator to 6.4
- Update AAP Operator to 2.6
- Fix image registry use with S3 bucket