### PR TITLE
Add cluster-config and virt-management policies

### DIFF
--- a/policies/cluster-configs/disable-self-provisioner/README.md
+++ b/policies/cluster-configs/disable-self-provisioner/README.md
@@ -1,0 +1,19 @@
+---
+# Disable Self-Provisioner
+
+## Description
+Prevents authenticated users from self-provisioning new OpenShift projects by clearing the subjects from the `self-provisioners` ClusterRoleBinding and setting `rbac.authorization.kubernetes.io/autoupdate: "false"` to stop OpenShift from restoring it automatically.
+
+## Dependencies
+- None
+
+## Details
+ACM Minimal Version: 2.12
+
+Documentation: [latest](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/disabling-self-provisioning)
+
+Notes:
+  - Targets all clusters in the ClusterSet via the `env-bound-placement` placement
+  - Uses `mustonlyhave` to enforce that `subjects` is empty — ACM will remove any subjects OpenShift re-adds
+  - The `autoupdate: "false"` annotation prevents the OpenShift RBAC controller from repopulating the binding between ACM reconciliations
+  - After applying, project creation must be delegated to a group or user explicitly via a separate ClusterRoleBinding

--- a/policies/cluster-configs/disable-self-provisioner/generator.yml
+++ b/policies/cluster-configs/disable-self-provisioner/generator.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: gen-policy-disable-self-provisioner
+policyDefaults:
+  namespace: bry-tam-policies
+  remediationAction: enforce
+  consolidateManifests: false
+  policySets:
+    - disable-self-provisioner
+  categories:
+    - "CM Configuration Management"
+  controls:
+    - "CM-2 Baseline Configuration"
+  standards:
+    - "NIST SP 800-53"
+  policyLabels:
+    policy_gen.name: disable-self-provisioner
+  severity: high
+
+placementBindingDefaults:
+  name: "disable-self-provisioner-binding"
+
+policies:
+  - name: disable-self-provisioner
+    description: "Disables the self-provisioner ClusterRoleBinding so authenticated users cannot create new projects, and prevents OpenShift from restoring it via the autoupdate annotation."
+    manifests:
+      - path: self-provisioner.yml
+        name: disable-self-provisioner-crb
+        complianceType: mustonlyhave
+
+policySets:
+  - name: disable-self-provisioner
+    placement:
+      placementName: "env-bound-placement"

--- a/policies/cluster-configs/disable-self-provisioner/kustomization.yaml
+++ b/policies/cluster-configs/disable-self-provisioner/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - generator.yml

--- a/policies/cluster-configs/disable-self-provisioner/self-provisioner.yml
+++ b/policies/cluster-configs/disable-self-provisioner/self-provisioner.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: self-provisioners
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "false"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: self-provisioner
+subjects: []

--- a/policies/cluster-configs/htpasswd-breakglass/README.md
+++ b/policies/cluster-configs/htpasswd-breakglass/README.md
@@ -1,0 +1,19 @@
+---
+# HTPasswd BreakGlass
+
+## Description
+Configures an htpasswd IdentityProvider named `BreakGlass-Emergency` on all clusters, creating a local `redhat` user for emergency access when other identity providers are unavailable.
+
+## Dependencies
+- None
+
+## Details
+ACM Minimal Version: 2.12
+
+Documentation: [latest](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/configuring-identity-providers#configuring-htpasswd-identity-provider)
+
+Notes:
+  - Targets all clusters in the ClusterSet via the `env-bound-placement` placement
+  - The htpasswd Secret is generated using the Sprig `htpasswd` function, which bcrypt-hashes the password at policy evaluation time
+  - The OAuth object uses `musthave` so existing identity providers are preserved and not removed
+  - **The password in `secret.yml` is a placeholder for the break-glass credential. In production, the password should be retrieved from a secure secrets manager such as HashiCorp Vault using a hub-side template lookup, rather than being stored in plaintext in the policy manifests.**

--- a/policies/cluster-configs/htpasswd-breakglass/generator.yml
+++ b/policies/cluster-configs/htpasswd-breakglass/generator.yml
@@ -1,0 +1,39 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: gen-policy-htpasswd-breakglass
+policyDefaults:
+  namespace: bry-tam-policies
+  remediationAction: enforce
+  consolidateManifests: false
+  policySets:
+    - htpasswd-breakglass
+  categories:
+    - "CM Configuration Management"
+  controls:
+    - "CM-2 Baseline Configuration"
+  standards:
+    - "NIST SP 800-53"
+  policyLabels:
+    policy_gen.name: htpasswd-breakglass
+  severity: high
+
+placementBindingDefaults:
+  name: "htpasswd-breakglass-binding"
+
+policies:
+  - name: htpasswd-breakglass
+    description: "Configures an htpasswd IdentityProvider named BreakGlass-Emergency with a local redhat user for emergency cluster access when other identity providers are unavailable."
+    manifests:
+      - path: secret.yml
+        name: htpasswd-breakglass-secret
+
+      - path: oauth.yml
+        name: htpasswd-breakglass-oauth
+        complianceType: musthave
+
+policySets:
+  - name: htpasswd-breakglass
+    placement:
+      placementName: "env-bound-placement"

--- a/policies/cluster-configs/htpasswd-breakglass/kustomization.yaml
+++ b/policies/cluster-configs/htpasswd-breakglass/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - generator.yml

--- a/policies/cluster-configs/htpasswd-breakglass/oauth.yml
+++ b/policies/cluster-configs/htpasswd-breakglass/oauth.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - name: BreakGlass-Emergency
+      mappingMethod: claim
+      type: HTPasswd
+      htpasswd:
+        fileData:
+          name: htpasswd-breakglass-secret

--- a/policies/cluster-configs/htpasswd-breakglass/secret.yml
+++ b/policies/cluster-configs/htpasswd-breakglass/secret.yml
@@ -1,0 +1,11 @@
+---
+object-templates-raw: |
+  - complianceType: mustonlyhave
+    objectDefinition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: htpasswd-breakglass-secret
+        namespace: openshift-config
+      data:
+        htpasswd: '{{ htpasswd "redhat" "redhat" | b64enc }}'

--- a/policies/cluster-configs/kustomization.yaml
+++ b/policies/cluster-configs/kustomization.yaml
@@ -20,3 +20,6 @@ resources:
   - machinesets/
   - monitoring/
   - nodes/
+  - disable-self-provisioner/
+  - htpasswd-breakglass/
+  - remove-kubeadmin/

--- a/policies/cluster-configs/remove-kubeadmin/README.md
+++ b/policies/cluster-configs/remove-kubeadmin/README.md
@@ -1,0 +1,19 @@
+---
+# Remove kubeadmin
+
+## Description
+Removes the `kubeadmin` Secret from the `kube-system` namespace, disabling the temporary bootstrap administrator account on all clusters.
+
+## Dependencies
+- An identity provider must be configured and verified working before this policy is enforced. Removing kubeadmin without a working IDP will lock all users out of the cluster.
+- It is strongly recommended to add a `dependencies` entry in the generator pointing to the Policy that configures cluster OAuth identity providers, ensuring kubeadmin is only removed after the IDP policy is Compliant.
+
+## Details
+ACM Minimal Version: 2.12
+
+Documentation: [latest](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/removing-kubeadmin)
+
+Notes:
+  - Targets clusters labeled `remove-kubeadmin=enabled` via `ft-remove-kubeadmin--enabled`
+  - Uses `mustnothave` — ACM will delete the Secret if it exists
+  - Verify IDP login works on each cluster before applying this policy

--- a/policies/cluster-configs/remove-kubeadmin/generator.yml
+++ b/policies/cluster-configs/remove-kubeadmin/generator.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: gen-policy-remove-kubeadmin
+policyDefaults:
+  namespace: bry-tam-policies
+  remediationAction: enforce
+  consolidateManifests: false
+  policySets:
+    - remove-kubeadmin
+  categories:
+    - "CM Configuration Management"
+  controls:
+    - "CM-2 Baseline Configuration"
+  standards:
+    - "NIST SP 800-53"
+  policyLabels:
+    policy_gen.name: remove-kubeadmin
+  severity: high
+
+placementBindingDefaults:
+  name: "remove-kubeadmin-binding"
+
+policies:
+  - name: remove-kubeadmin
+    description: "Removes the kubeadmin secret from kube-system to disable the temporary bootstrap admin user after an identity provider has been configured."
+    manifests:
+      - path: kubeadmin.yml
+        name: remove-kubeadmin-secret
+        complianceType: mustnothave
+
+policySets:
+  - name: remove-kubeadmin
+    placement:
+      placementName: "ft-remove-kubeadmin--enabled"

--- a/policies/cluster-configs/remove-kubeadmin/kubeadmin.yml
+++ b/policies/cluster-configs/remove-kubeadmin/kubeadmin.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeadmin
+  namespace: kube-system

--- a/policies/cluster-configs/remove-kubeadmin/kustomization.yaml
+++ b/policies/cluster-configs/remove-kubeadmin/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - generator.yml

--- a/policies/kustomization.yaml
+++ b/policies/kustomization.yaml
@@ -24,5 +24,6 @@ resources:
   - ./cluster-health/
   - ./security/
   - ./multicluster-data
+  - ./virt-management/
 
 

--- a/policies/virt-management/kustomization.yaml
+++ b/policies/virt-management/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - vm-delete-protection/

--- a/policies/virt-management/vm-delete-protection/README.md
+++ b/policies/virt-management/vm-delete-protection/README.md
@@ -1,0 +1,20 @@
+---
+# VM Delete Protection
+
+## Description
+Ensures all VirtualMachines that are not explicitly labeled `admin-allow-delete` have the label `kubevirt.io/vm-delete-protection: "True"` set. A ValidatingAdmissionPolicy enforces that the protection label cannot be removed unless `admin-allow-delete` is present on the VM.
+
+## Dependencies
+- None
+
+## Details
+ACM Minimal Version: 2.12
+
+Documentation: [latest](https://docs.redhat.com/en/documentation/openshift_virtualization/latest/html/virtual_machines/index)
+
+Notes:
+  - Targets clusters labeled `ocp-virt=enabled` via the `ft-ocp-virt--enabled` placement
+  - The ConfigurationPolicy uses an `objectSelector` with `DoesNotExist` on `admin-allow-delete` to target only unexempted VMs, and a `namespaceSelector` that excludes `kube-*`, `openshift-*`, `open-*`, `default*`, `multicluster-engine`, and `hive` namespaces
+  - Uses `musthave` so the label is added without disturbing other existing labels on the VM
+  - The `ValidatingAdmissionPolicy` (VAP) blocks any UPDATE to a VirtualMachine that would remove `kubevirt.io/vm-delete-protection: "True"` unless the `admin-allow-delete` label is present on the updated object
+  - To exempt a VM from delete protection, add the label `admin-allow-delete` with any value; the ConfigurationPolicy will no longer target it and the VAP will permit label removal

--- a/policies/virt-management/vm-delete-protection/delete-protection.yml
+++ b/policies/virt-management/vm-delete-protection/delete-protection.yml
@@ -1,0 +1,6 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm-delete-protection: "True"

--- a/policies/virt-management/vm-delete-protection/generator.yml
+++ b/policies/virt-management/vm-delete-protection/generator.yml
@@ -1,0 +1,56 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: gen-policy-vm-delete-protection
+policyDefaults:
+  namespace: bry-tam-policies
+  remediationAction: enforce
+  consolidateManifests: false
+  policySets:
+    - vm-delete-protection
+  categories:
+    - "CM Configuration Management"
+  controls:
+    - "CM-2 Baseline Configuration"
+  standards:
+    - "NIST SP 800-53"
+  policyLabels:
+    policy_gen.name: vm-delete-protection
+  severity: high
+
+placementBindingDefaults:
+  name: "vm-delete-protection-binding"
+
+policies:
+  - name: vm-delete-protection
+    description: "Ensures all VirtualMachines without the admin-allow-delete label have the kubevirt.io/vm-delete-protection label set, preventing accidental deletion."
+    manifests:
+      - path: delete-protection.yml
+        name: vm-delete-protection-label
+        complianceType: musthave
+        namespaceSelector:
+          include:
+            - "*"
+          exclude:
+            - kube-*
+            - openshift-*
+            - open-*
+            - default*
+            - multicluster-engine
+            - hive
+        objectSelector:
+          matchExpressions:
+            - key: admin-allow-delete
+              operator: DoesNotExist
+
+      - path: vap.yml
+        name: vm-delete-protection-vap
+
+      - path: vap-binding.yml
+        name: vm-delete-protection-vap-binding
+
+policySets:
+  - name: vm-delete-protection
+    placement:
+      placementName: "ft-ocp-virt--enabled"

--- a/policies/virt-management/vm-delete-protection/kustomization.yaml
+++ b/policies/virt-management/vm-delete-protection/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+  - generator.yml

--- a/policies/virt-management/vm-delete-protection/vap-binding.yml
+++ b/policies/virt-management/vm-delete-protection/vap-binding.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: vm-delete-protection
+spec:
+  policyName: vm-delete-protection
+  validationActions:
+    - Deny

--- a/policies/virt-management/vm-delete-protection/vap.yml
+++ b/policies/virt-management/vm-delete-protection/vap.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: vm-delete-protection
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["kubevirt.io"]
+        apiVersions: ["v1"]
+        resources: ["virtualmachines"]
+        operations: ["UPDATE"]
+  variables:
+    - name: protectionLabel
+      expression: "'kubevirt.io/vm-delete-protection'"
+    - name: adminLabel
+      expression: "'admin-allow-delete'"
+  validations:
+    - expression: >-
+        !(variables.protectionLabel in oldObject.metadata.labels) ||
+        oldObject.metadata.labels[variables.protectionLabel] != "True" ||
+        (variables.protectionLabel in object.metadata.labels &&
+         object.metadata.labels[variables.protectionLabel] == "True") ||
+        variables.adminLabel in object.metadata.labels
+      message: "Removing kubevirt.io/vm-delete-protection is not permitted unless the admin-allow-delete label is present"


### PR DESCRIPTION
- disable-self-provisioner: clears self-provisioners ClusterRoleBinding subjects and sets autoupdate=false; targets all clusters
- remove-kubeadmin: removes the kubeadmin bootstrap secret using mustnothave; recommends dependency on OAuth IDP policy
- htpasswd-breakglass: configures an HTPasswd IdentityProvider named BreakGlass-Emergency using the Sprig htpasswd function to bcrypt-hash credentials at policy evaluation time; musthave preserves existing IDPs
- virt-management/vm-delete-protection: labels VirtualMachines without admin-allow-delete with kubevirt.io/vm-delete-protection=True using an objectSelector and namespaceSelector; a ValidatingAdmissionPolicy with CEL variables blocks removal of the protection label unless admin-allow-delete is present on the updated object